### PR TITLE
Fixed bug regarding song selection for playlists

### DIFF
--- a/src/components/OneSongFromPl.js
+++ b/src/components/OneSongFromPl.js
@@ -17,7 +17,7 @@ const OneSongFromPl = ({ selectedAll, song }) => {
   };
 
   useEffect(() => {
-    if (selectedAll) {
+    if (selectedAll && !checked) {
       setChecked(true);
       setSelectedSongs((selectedSongs) => [...selectedSongs, song.uri]);
     } else if (!selectedAll) {


### PR DESCRIPTION
Fixed a bug where the current selected song(s) is added twice when a user manually selects a song, presses "Select all" afterwards and proceeds to transfer the playlist.